### PR TITLE
Fix every starting character being super-powered when not on quickstart

### DIFF
--- a/FreeEnt/generator.py
+++ b/FreeEnt/generator.py
@@ -910,6 +910,7 @@ def build(romfile, options, force_recompile=False):
 
     if not (options.quickstart or options.test_settings.get('quickstart', False)):
         env.add_substitution('quickstart', '')
+        env.add_substitution('quickstart superhero', '')
     elif not env.options.flags.has('superhero_challenge'):
         env.add_substitution('quickstart superhero', '')
 


### PR DESCRIPTION
See the title. Forgot to ensure the MakeSuperhero event in opening.f4c gets subbed out when not on quickstart; sorry about that.