### PR TITLE
Fixing KeyError thrown in fusoya_rando

### DIFF
--- a/FreeEnt/fusoya_rando.py
+++ b/FreeEnt/fusoya_rando.py
@@ -495,7 +495,7 @@ def apply(env):
         if maybe_spells:
             for spell in ALL_SPELLS_BY_LOCATION_TIERING:
                 if env.rnd.random() < MAYBE_THRESHOLD:
-                    available_spells.pop(spell)
+                    available_spells.pop(spell, None)
         
         shuffled_spells = [spell for spell in available_spells]
         env.rnd.shuffle(shuffled_spells)


### PR DESCRIPTION
On -fusoya:location,maybe without J spells, the J spells get popped off the dictionary, and *then* every spell (including the J spells) have a 15% chance to be popped off the dictionary... but of course, pop() does not appreciate it when the key you're trying to remove does not exist. So, make it pop(..., None) to avoid throwing an error that halts the program execution. Whoops!