### PR TITLE
Add a test for pink tail when kpink is enabled

### DIFF
--- a/FreeEnt/core_rando.py
+++ b/FreeEnt/core_rando.py
@@ -728,6 +728,9 @@ def apply(env):
         if env.options.flags.has('no_free_key_item'):
             tests.append('dmist')
 
+        if env.options.flags.has('key_item_from_pink_tail'):
+            tests.append('#item.Pink')
+
         underground_path_disallowed = []
         if not env.options.flags.has('bosses_vanilla') and not env.options.flags.has('bosses_unsafe'):
             # must be able to access underground without encountering, golbez, wyvern, valvalis or odin replacement


### PR DESCRIPTION
https://discord.com/channels/411615349579186178/1362929603722870854 for bug discussion in the discord.

So far have generated 20k seeds with this change and none of them have the pink tail item locked behind the pink tail. without the change, I had about four thousand seeds out of one hundred thousand total with a pink tail locking itself, and about 800 of those seeds also had the pink tail as an objective..