### PR TITLE
Fix Ctreasure miab crash

### DIFF
--- a/FreeEnt/scripts/rewards.f4c
+++ b/FreeEnt/scripts/rewards.f4c
@@ -661,6 +661,12 @@ msfpatch {
         rtl
 
     %TreasureCharacter:
+        // still need to check if this miab could have been a key item;
+        // if yes, then increment the zonk counter (since char != KI)
+        pla
+        beq $+SkipZonk
+        inc $_Rewards__ZonkChecksCount
+    %SkipZonk:
         rtl
 }
 


### PR DESCRIPTION
A value pushed to the stack was not being pulled before rtl'ing after a successful "it's a character reward" check from a miab, in rewards.f4c. That's been changed (and the zonk counter is correctly incremented if it should be, which was the point of pushing that value to the stack earlier).